### PR TITLE
upgrade docker image to node:18.17.1-alpine

### DIFF
--- a/apps/awaken-overlay/Dockerfile
+++ b/apps/awaken-overlay/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.16-alpine AS base
+FROM node:18.17.1-alpine AS base
 RUN apk add --no-cache curl libc6-compat python3
 RUN curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
 


### PR DESCRIPTION
Snyk detected some vulnerabilities on the `18.16-alpine` node image so we can upgrade to `8.17.1-alpine` 